### PR TITLE
feat: content가 수정가능하도록하고, DB로 업데이트하게 구현했습니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ goorm.manifest
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*.swp

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
-    "web-vitals": "^1.0.1"
+    "web-vitals": "^1.0.1",
+    "prop-types": "^15.7.2"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -21,7 +22,7 @@
     "eject": "react-scripts eject",
     "lint": "../node_modules/.bin/eslint .",
     "lint:fix": "../node_modules/.bin/eslint . --fix",
-    "pre-commit" : "../node_modules/.bin/lint-staged"
+    "pre-commit": "../node_modules/.bin/lint-staged"
   },
   "eslintConfig": {
     "extends": [

--- a/client/src/components/ContentInList.js
+++ b/client/src/components/ContentInList.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+
+const ContentInList = ({ content, thumbsUp }) => {
+  return (
+    <div key={content.id}>
+      <h3>
+        <Link
+          to={{
+            pathname: `/contents/view/${content.id}`,
+            datum: content,
+          }}
+        >
+          {content.title} &nbsp;
+        </Link>
+
+        <button type="button" value={content.id} onClick={thumbsUp}>
+          👍{content.thumbs}
+        </button>
+      </h3>
+      {content.date}에 작성
+      <hr />
+    </div>
+  );
+};
+const contentProps = {
+  id: PropTypes.id,
+  title: PropTypes.string,
+  thumbs: PropTypes.int,
+  date: PropTypes.string,
+};
+ContentInList.propTypes = {
+  content: PropTypes.shape(contentProps).isRequired,
+  thumbsUp: PropTypes.func.isRequired,
+};
+export default ContentInList;

--- a/client/src/components/ContentInList.js
+++ b/client/src/components/ContentInList.js
@@ -9,7 +9,7 @@ const ContentInList = ({ content, thumbsUp }) => {
         <Link
           to={{
             pathname: `/contents/view/${content.id}`,
-            datum: content,
+            data: content,
           }}
         >
           {content.title} &nbsp;

--- a/client/src/components/PageContentsList.js
+++ b/client/src/components/PageContentsList.js
@@ -16,7 +16,7 @@ const PageContentsList = () => {
     if (latestContents.current === undefined) return; // nothing to update
     latestContents.current.forEach((data) => {
       if (data.modified === true) {
-        updateList.push({ _id: data.id, thumbs: data.thumbs });
+        updateList.push({ id: data.id, thumbs: data.thumbs });
       }
     });
 

--- a/client/src/components/PageContentsList.js
+++ b/client/src/components/PageContentsList.js
@@ -73,7 +73,7 @@ const PageContentsList = () => {
                     datum: content,
                   }}
                 >
-                  {content.title}
+                  {content.title} &nbsp;
                 </Link>
 
                 <button type="button" value={content.id} onClick={thumbsUp}>

--- a/client/src/components/PageContentsList.js
+++ b/client/src/components/PageContentsList.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
-import { Link } from "react-router-dom";
 import FetchContent from "../api/FetchContent";
+import ContentInList from "./ContentInList";
 import "../css/Contents.css";
 
 const PageContentsList = () => {
@@ -20,8 +20,6 @@ const PageContentsList = () => {
       }
     });
 
-    // setstate async problem -> Mobx?
-    // https://techblog.woowahan.com/2599/
     if (updateList.length > 0) {
       await fetch("/contents/update", {
         method: "PATCH",
@@ -65,24 +63,7 @@ const PageContentsList = () => {
       <div className="contentsList">
         {contents &&
           contents.map((content) => (
-            <div key={content.id}>
-              <h3>
-                <Link
-                  to={{
-                    pathname: `/contents/view/${content.id}`,
-                    datum: content,
-                  }}
-                >
-                  {content.title} &nbsp;
-                </Link>
-
-                <button type="button" value={content.id} onClick={thumbsUp}>
-                  👍{content.thumbs}
-                </button>
-              </h3>
-              {content.date}에 작성
-              <hr />
-            </div>
+            <ContentInList content={content} thumbsUp={thumbsUp} />
           ))}
       </div>
     </div>

--- a/client/src/components/ViewContentDetail.js
+++ b/client/src/components/ViewContentDetail.js
@@ -1,17 +1,19 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import "../css/ViewContentDetail.css";
 
-const ViewContent = () => {
+const ViewContentDetail = () => {
   const datum = useLocation()?.datum;
   const [editable, setEditable] = useState(false);
   const [postData, setPostData] = useState({
-    id: "",
-    title: "",
-    content: "",
-    thumbs: "",
-    date: "",
+    id: datum.id,
+    title: datum.title,
+    content: datum.content,
+    thumbs: datum.thumbs,
+    date: datum.date,
+    modified: false,
   });
+  const latestData = useRef(postData);
   const setContent = (value) => {
     const newData = {
       id: postData.id,
@@ -19,8 +21,10 @@ const ViewContent = () => {
       content: value,
       thumbs: postData.thumbs,
       date: postData.date,
+      modified: true,
     };
     setPostData(newData);
+    latestData.current = newData;
   };
   const setTitle = (value) => {
     const newData = {
@@ -29,17 +33,33 @@ const ViewContent = () => {
       content: postData.content,
       thumbs: postData.thumbs,
       date: postData.date,
+      modified: true,
     };
     setPostData(newData);
+    latestData.current = newData;
+  };
+  const Update = async () => {
+    if (latestData.current.modified === true) {
+      const updateArr = [
+        {
+          id: latestData.current.id,
+          title: latestData.current.title,
+          content: latestData.current.content,
+          date: new Date(Date.now()),
+        },
+      ];
+      console.log(updateArr);
+      await fetch("/contents/update", {
+        method: "PATCH",
+        body: JSON.stringify(updateArr),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
   };
   useEffect(() => {
-    setPostData({
-      id: datum.id,
-      title: datum.title,
-      content: datum.content,
-      thumbs: datum.thumbs,
-      date: datum.date,
-    });
+    return Update;
   }, []);
   return (
     <div key={postData.id}>
@@ -47,7 +67,10 @@ const ViewContent = () => {
         <div className="view-content">
           {editable ? (
             <h2 className="view-style">
-              <input value={postData.title} />
+              <input
+                value={postData.title}
+                onChange={({ target: { value } }) => setTitle(value)}
+              />
               &nbsp; 👍 : {postData.thumbs}{" "}
             </h2>
           ) : (
@@ -70,11 +93,11 @@ const ViewContent = () => {
       </div>
       <div>
         <button onClick={() => setEditable((prev) => !prev)}>
-          {editable ? "Cancel" : "Edit"}
+          {editable ? "Save" : "Edit"}
         </button>
       </div>
     </div>
   );
 };
 
-export default ViewContent;
+export default ViewContentDetail;

--- a/client/src/components/ViewContentDetail.js
+++ b/client/src/components/ViewContentDetail.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import "../css/ViewContentDetail.css";
 
 const ViewContentDetail = () => {
@@ -38,7 +38,11 @@ const ViewContentDetail = () => {
     setPostData(newData);
     latestData.current = newData;
   };
+  const toggleEditable = () => {
+    setEditable((prev) => !prev);
+  };
   const Update = async () => {
+    toggleEditable();
     if (latestData.current.modified === true) {
       const updateArr = [
         {
@@ -58,9 +62,7 @@ const ViewContentDetail = () => {
       });
     }
   };
-  useEffect(() => {
-    return Update;
-  }, []);
+
   return (
     <div key={postData.id}>
       <div>
@@ -83,7 +85,7 @@ const ViewContentDetail = () => {
         <hr />
         {editable ? (
           <input
-            type="content"
+            type="contentDetail"
             value={postData.content}
             onChange={({ target: { value } }) => setContent(value)}
           />
@@ -92,9 +94,19 @@ const ViewContentDetail = () => {
         )}
       </div>
       <div>
-        <button onClick={() => setEditable((prev) => !prev)}>
-          {editable ? "Save" : "Edit"}
-        </button>
+        {editable ? (
+          <>
+            <button onClick={Update}> Save </button>
+            <button onClick={toggleEditable}>Cancel</button>
+          </>
+        ) : (
+          <>
+            <button onClick={toggleEditable}> Edit</button>
+            <Link to="../">
+              <button> Back </button>
+            </Link>
+          </>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/ViewContentDetail.js
+++ b/client/src/components/ViewContentDetail.js
@@ -1,16 +1,16 @@
-import React, { useEffect, useState, useRef } from "react";
+import React, { useState, useRef } from "react";
 import { useLocation, Link } from "react-router-dom";
 import "../css/ViewContentDetail.css";
 
 const ViewContentDetail = () => {
-  const datum = useLocation()?.datum;
+  const data = useLocation()?.data;
   const [editable, setEditable] = useState(false);
   const [postData, setPostData] = useState({
-    id: datum.id,
-    title: datum.title,
-    content: datum.content,
-    thumbs: datum.thumbs,
-    date: datum.date,
+    id: data.id,
+    title: data.title,
+    content: data.content,
+    thumbs: data.thumbs,
+    date: data.date,
     modified: false,
   });
   const latestData = useRef(postData);
@@ -52,7 +52,7 @@ const ViewContentDetail = () => {
           date: new Date(Date.now()),
         },
       ];
-      console.log(updateArr);
+      // console.log(updateArr);
       await fetch("/contents/update", {
         method: "PATCH",
         body: JSON.stringify(updateArr),

--- a/client/src/components/ViewContentDetail.js
+++ b/client/src/components/ViewContentDetail.js
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import "../css/ViewContent.css";
+import "../css/ViewContentDetail.css";
 
 const ViewContent = () => {
   const datum = useLocation()?.datum;
+  const [editable, setEditable] = useState(false);
   const [postData, setPostData] = useState({
     id: "",
     title: "",
@@ -11,7 +12,26 @@ const ViewContent = () => {
     thumbs: "",
     date: "",
   });
-
+  const setContent = (value) => {
+    const newData = {
+      id: postData.id,
+      title: postData.title,
+      content: value,
+      thumbs: postData.thumbs,
+      date: postData.date,
+    };
+    setPostData(newData);
+  };
+  const setTitle = (value) => {
+    const newData = {
+      id: postData.id,
+      title: value,
+      content: postData.content,
+      thumbs: postData.thumbs,
+      date: postData.date,
+    };
+    setPostData(newData);
+  };
   useEffect(() => {
     setPostData({
       id: datum.id,
@@ -25,13 +45,33 @@ const ViewContent = () => {
     <div key={postData.id}>
       <div>
         <div className="view-content">
-          <h2 className="view-style">
-            {postData.title} &nbsp; 👍 : {postData.thumbs}{" "}
-          </h2>
+          {editable ? (
+            <h2 className="view-style">
+              <input value={postData.title} />
+              &nbsp; 👍 : {postData.thumbs}{" "}
+            </h2>
+          ) : (
+            <h2 className="view-style">
+              {postData.title} &nbsp; 👍 : {postData.thumbs}{" "}
+            </h2>
+          )}
         </div>
-        <h4 className="data-style">Date : {postData.date} </h4>
+        <p className="date-style">Date : {postData.date} </p>
         <hr />
-        <h3>{postData.content} </h3>
+        {editable ? (
+          <input
+            type="content"
+            value={postData.content}
+            onChange={({ target: { value } }) => setContent(value)}
+          />
+        ) : (
+          <h3>{postData.content} </h3>
+        )}
+      </div>
+      <div>
+        <button onClick={() => setEditable((prev) => !prev)}>
+          {editable ? "Cancel" : "Edit"}
+        </button>
       </div>
     </div>
   );

--- a/client/src/components/WriteContent.js
+++ b/client/src/components/WriteContent.js
@@ -15,7 +15,7 @@ const WriteContent = () => {
       <form>
         <input
           type="title"
-          className="title-style"
+          className="post-title-style"
           value={title}
           onChange={({ target: { value } }) => setTitle(value)}
           placeholder="이곳에 제목을 입력하세요"
@@ -28,9 +28,10 @@ const WriteContent = () => {
           onChange={({ target: { value } }) => setContent(value)}
           placeholder="이곳에 내용을 입력하세요"
         />
-        <div className="button-style">
+        <div className="post-button-style">
           <Link to="/">
             <button type="reset"> BACK </button>
+
             <button type="submit" onClick={requestPost}>
               {" "}
               POST{" "}

--- a/client/src/css/Navigation.css
+++ b/client/src/css/Navigation.css
@@ -4,7 +4,7 @@
 	width : 100%;
 	display : flex;
 	color: white;
-	padding : 20px;
+	padding : 20px 0px 20px 20px;
 	padding-bottom : 0px;
 	font-weight : 600;
 	font-size : 20px;

--- a/client/src/css/PageTitle.css
+++ b/client/src/css/PageTitle.css
@@ -1,5 +1,5 @@
 .page-title {
-	display: flex;
+    display: flex;
     padding-left: 60px;
     text-align: left;
     align-items: baseline;
@@ -12,5 +12,5 @@
     border: 2px solid black;
 }
 .title-style{
-	padding : 10px 100px 0px 0px;
+    padding : 10px 100px 0px 0px;
 }

--- a/client/src/css/PageTitle.css
+++ b/client/src/css/PageTitle.css
@@ -1,8 +1,10 @@
 .page-title {
-	display : flex;
-	padding-left : 60px;
-	text-align : left;
-	align-items : baseline;
+	display: flex;
+    padding-left: 60px;
+    text-align: left;
+    align-items: baseline;
+    align-content: flex-end;
+    justify-content: space-evenly;
 }
 .button-style {
     color: black;
@@ -10,5 +12,5 @@
     border: 2px solid black;
 }
 .title-style{
-	padding-right : 300px;
+	padding : 10px 100px 0px 0px;
 }

--- a/client/src/css/ViewContent.css
+++ b/client/src/css/ViewContent.css
@@ -1,6 +1,0 @@
-.view-style { 
-	margin-bottom: 0px ;
-}
-.data-style { 
-	margin: 0px;
-}

--- a/client/src/css/ViewContentDetail.css
+++ b/client/src/css/ViewContentDetail.css
@@ -2,9 +2,9 @@ input {
 	size : 10;
 	height : 32;
 }
-input[type="content"] {
+input[type="contentDetail"] {
 	width : 80%;	
-	height : 30%;
+	height : 350px;
 }
 .view-style { 
 	width : 80%;

--- a/client/src/css/ViewContentDetail.css
+++ b/client/src/css/ViewContentDetail.css
@@ -1,0 +1,15 @@
+input {
+	size : 10;
+	height : 32;
+}
+input[type="content"] {
+	width : 80%;	
+	height : 30%;
+}
+.view-style { 
+	width : 80%;
+	margin-bottom: 0px ;
+}
+.date-style { 
+	margin: 3px 0px 3px 0px;
+}

--- a/client/src/css/WriteContent.css
+++ b/client/src/css/WriteContent.css
@@ -1,12 +1,14 @@
-.title-style { 
+.post-title-style { 
 	padding : 0px;
 	width: 80%;
+	text-align : center;
 }
 .content-style { 
 	width: 80%;
 	height: 450px;
+	text-align : center;
 }
-.button-style { 
+.post-button-style { 
 	margin: 10px; 
 	text-align : center;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "lint-staged": "^11.2.0"
       },
       "devDependencies": {
-        "husky": "^7.0.2"
+        "husky": "^7.0.2",
+        "prop-types": "^15.7.2"
       }
     },
     "client": {
@@ -42,7 +43,8 @@
         "eslint-plugin-react-hooks": "^4.2.0",
         "husky": "^7.0.0",
         "lint-staged": "^11.1.2",
-        "prettier": "^2.4.0"
+        "prettier": "^2.4.0",
+        "prop-types": "^15.7.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -33743,6 +33745,7 @@
         "husky": "^7.0.0",
         "lint-staged": "^11.1.2",
         "prettier": "^2.4.0",
+        "prop-types": "^15.7.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "root-directory",
   "version": "0.2.0",
   "devDependencies": {
-    "husky": "^7.0.2"
+    "husky": "^7.0.2",
+    "prop-types": "^15.7.2"
   },
   "scripts": {
     "prepare": "husky install"

--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -44,17 +44,23 @@ router.post('/', async (req, res) => {
 // req.body : must  be array
 router.patch('/update', async (req, res) => {
   // 문제 : 식별자(정확한 주소) 명시 안함
-  console.log(req.body);
+  let isSuccess = true;
   req.body.forEach(async (data) => {
     const dataWithoutId = data;
+    const updateId = { _id: mongoose.Types.ObjectId(data.id) };
     delete dataWithoutId.id;
 
-    const updateId = { _id: mongoose.Types.ObjectId(data.id) };
-    await contents.contentSchema.updateOne(updateId, {
+    const retVal = await contents.contentSchema.updateOne(updateId, {
       $set: dataWithoutId,
     });
+    if (retVal.n !== retVal.nModified) {
+      res.status(400).send('wrong request ');
+      isSuccess = false;
+    }
   });
-  res.status(200);
+  if (isSuccess === true) {
+    res.status(200).send('success request');
+  }
 });
 
 module.exports = router;

--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -50,11 +50,11 @@ router.patch('/update', async (req, res) => {
     const updateId = { _id: mongoose.Types.ObjectId(data.id) };
     delete dataWithoutId.id;
 
-    const retVal = await contents.contentSchema.updateOne(updateId, {
+    const dbResponse = await contents.contentSchema.updateOne(updateId, {
       $set: dataWithoutId,
     });
-    if (retVal.n !== retVal.nModified) {
-      res.status(400).send('wrong request ');
+    if (dbResponse.n !== dbResponse.nModified) {
+      res.status(400).send('wrong request');
       isSuccess = false;
     }
   });

--- a/server/routes/content.js
+++ b/server/routes/content.js
@@ -26,7 +26,6 @@ router.get('/view/:id', async (req, res) => {
   }
 });
 router.post('/', async (req, res) => {
-  console.log(req.body);
   try {
     // for MAX
     contents.contentSchema.create(req.body, (err, data) => {
@@ -42,13 +41,17 @@ router.post('/', async (req, res) => {
 });
 
 // https://www.geeksforgeeks.org/mongodb-updatemany-method-db-collection-updatemany/?ref=rp
+// req.body : must  be array
 router.patch('/update', async (req, res) => {
   // 문제 : 식별자(정확한 주소) 명시 안함
+  console.log(req.body);
   req.body.forEach(async (data) => {
-    const updateId = { _id: data._id };
-    const thumbCount = { thumbs: data.thumbs };
+    const dataWithoutId = data;
+    delete dataWithoutId.id;
+
+    const updateId = { _id: mongoose.Types.ObjectId(data.id) };
     await contents.contentSchema.updateOne(updateId, {
-      $set: thumbCount,
+      $set: dataWithoutId,
     });
   });
   res.status(200);


### PR DESCRIPTION
#PR (updated 21 11/27)

## 무엇이 변경되었나요?

### Client
-	css 일부를 수정해습니다.
-  ViewContentDetail에서 title과 content를 수정가능하도록했습니다.
~~- 해당 내용을 클린업 함수로 DB에 업데이트 되도록했습니다.~~
- ViewContentDetail에서 save 버튼을 누르면 DB에 업데이트하도록 했습니다.

### Server
- Patch (path :/content/update) API를 수정하여 서버에서는 _id 카테고리로 사용하고, 클라이언트에서 보내는 정보들은 id 카테고리로 오도록 정했습니다.


## 관련된 ISSUE 혹은 PR은 무엇인가요?

- 없습니다.

## 추가로 알아야 할 것을 알려주세요! (선택사항)

~~- 적다보니 생각난 것인데, ViewContentDetail에서 save 버튼을 누르면 DB에 업데이트할지 고민중입니다.~~ 
- props를 상속받을 때 타입체크해주는 prop-types 라이브러리를 추가했습니다.
- 간단하게 리팩토링하고자하는 데 MVC 기준으로 나누려고하니까 아직 잘 모르겠네요 
 
다른 사람이 알면 좋을 정보를 여기에 적어주세요.

- client 파트는 지난번 thumbsUp 구현한 내용과 비슷한 방법으로 해결했습니다.